### PR TITLE
use fs.mkdirSync() instead of fs.mkdir()

### DIFF
--- a/ep_autotxtexport.js
+++ b/ep_autotxtexport.js
@@ -7,7 +7,7 @@ exports.mkdirtxtexport = function(hook_name, args, cb) {
     var s = fs.stat(txtexportdir, function (err) {
         if (err) {
             if (err.code === 'ENOENT') {
-                fs.mkdir(txtexportdir);
+                fs.mkdirSync(txtexportdir);
             }
             else {
                 console.error(err);


### PR DESCRIPTION
mkdir() requires a mandatory callback argument, that is not given here.
It needs to be reverted to sync or restructured, otherwise the code will break
when trying to create txtexportdir.

Tested on current Etherpad development branch, linux, nodejs 10.6.0, `txtexportdir` directory not existing.

[2018-08-11 15:22:06.275] [ERROR] console - TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at makeCallback (fs.js:141:11)
    at Object.mkdir (fs.js:720:16)
    at /xxx/etherpad-lite/node_modules/ep_autotxtexport/ep_autotxtexport.js:10:20
    at /xxx/etherpad-lite/src/node_modules/npm/node_modules/graceful-fs/polyfills.js:284:29
    at FSReqWrap.oncomplete (fs.js:158:21)